### PR TITLE
Symptoms form redirects to calander

### DIFF
--- a/app/controllers/period_day_symptoms_controller.rb
+++ b/app/controllers/period_day_symptoms_controller.rb
@@ -19,7 +19,7 @@ class PeriodDaySymptomsController < ApplicationController
     @period = Period.find(params[:period_id])
     @period_day_symptom.period = @period
     if @period_day_symptom.save!
-      redirect_to period_path(@period)
+      redirect_to periods_path(@period)
     else
       render :new
     end


### PR DESCRIPTION
I changed the Symptoms form Submit button to redirect to the calendar so we can view past entries 